### PR TITLE
refactor setup()

### DIFF
--- a/ckanext/datastore_refresh/model.py
+++ b/ckanext/datastore_refresh/model.py
@@ -5,9 +5,12 @@ from ckan.model.package import Package
 from sqlalchemy import types, Column, Table, ForeignKey, orm, text
 
 import datetime
-import logging    
+import logging
 
 log = logging.getLogger(__name__)
+
+refresh_dataset_datastore_table = None
+
 
 refresh_dataset_datastore_table = Table(
     'refresh_dataset_datastore',
@@ -80,5 +83,5 @@ properties={
 
 
 def setup():
-    if not metadata.tables['refresh_dataset_datastore']:
-        metadata.create(refresh_dataset_datastore_table)
+    if not refresh_dataset_datastore_table.exists():
+        refresh_dataset_datastore_table.create()


### PR DESCRIPTION
This PR fixes #8 

I refactored `setup()` so that it checks if the table exists in DB before creating it. 

I researched this, found that: "`metadata.tables['objects']` have been explicitly declared and these objects are typically accessed directly as module-level variables in an application. Once a Table has been defined, it has a full set of accessors which allow inspection of its properties."